### PR TITLE
update mor1kx_cpu.v to work with current verilator

### DIFF
--- a/pythondata_cpu_mor1kx/verilog/.github/workflows/ci.yml
+++ b/pythondata_cpu_mor1kx/verilog/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: ci
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   verilator-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout Repository
       - name: Checkout
@@ -21,7 +26,7 @@ jobs:
           verilator --lint-only rtl/verilog/*.v +incdir+rtl/verilog
 
   or1k-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       LD_LIBRARY_PATH: "/tmp/tools/lib"
       EXPECTED_FAILURES: ${{ matrix.env.EXPECTED_FAILURES }}
@@ -40,7 +45,6 @@ jobs:
           pip3 install fusesoc
           export PATH=$PATH:$HOME/.local/bin
           fusesoc --version
-          fusesoc init -y
 
       # Install Toolchain
       - name: Install Toolchain
@@ -62,6 +66,7 @@ jobs:
           git clone --depth 1 https://github.com/openrisc/or1k-tests.git -b v1.0.5
           cd or1k-tests/native
           make -j8
+          fusesoc library add fusesoc_cores https://github.com/fusesoc/fusesoc-cores
           fusesoc library add mor1kx-generic https://github.com/openrisc/mor1kx-generic.git
           fusesoc library add intgen https://github.com/openrisc/intgen.git
           fusesoc library add elf-loader https://github.com/fusesoc/elf-loader.git
@@ -107,7 +112,7 @@ jobs:
           - { EXPECTED_FAILURES: "or1k-cy or1k-ext", EXTRA_CORE_ARGS: "--feature_ext NONE" }
 
   formal-verification:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       #Checkout Repository
       - name: Checkout
@@ -119,7 +124,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install g++ gperf build-essential bison flex \
             libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot \
-            pkg-config python python3 libboost-system-dev \
+            pkg-config python2 python3 libboost-system-dev \
             libboost-python-dev libboost-filesystem-dev zlib1g-dev
           pip3 install dataclasses
 

--- a/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_cpu.v
+++ b/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_cpu.v
@@ -198,13 +198,11 @@ module mor1kx_cpu
 	// synthesis translate_off
 `ifndef SYNTHESIS
    /* Provide interface hooks for register functions. */
+	`include "mor1kx_utils.vh"
+	localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
+                                                  OPTION_RF_NUM_SHADOW_GPR);
    generate
       if (OPTION_CPU=="CAPPUCCINO") begin : monitor
-
-`include "mor1kx_utils.vh"
-         localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
-                                                       OPTION_RF_NUM_SHADOW_GPR);
-
          function [OPTION_OPERAND_WIDTH-1:0] get_gpr;
             // verilator public
             input [RF_ADDR_WIDTH-1:0] gpr_num;


### PR DESCRIPTION
the changes to ``ci.yml`` are just the result of copy-pasting from the current ``mor1kx`` repository.

otherwise, ``mor1kx_cpu.v`` has been updated to fix a problem that prevents correct compilation with verilator in the current version. the included change allows the design to compile.